### PR TITLE
Let the user pass either the name or the ID of the encounter

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,12 +6,14 @@ from src.models import ReportRequest
 
 def parse_args() -> argparse.Namespace:
     arg_parser = argparse.ArgumentParser(description='Analyze classic Warcraft Logs reports.')
-    sub_parsers = arg_parser.add_subparsers(dest="command", required=True)
+    sub_parsers = arg_parser.add_subparsers(dest='command', required=True)
 
     analyze_parser = sub_parsers.add_parser(name='analyze', help='Analyze a Warcraft Logs report.')
     analyze_parser.add_argument('report', help='The code of the report to analyze.')
-    analyze_parser.add_argument('--encounter', help='The ID of the encounter to analyze.', type=int)
-    analyze_parser.add_argument('--fights', nargs='+', help='The IDs of the fights to analyze.', type=int, default=[])
+    analyze_parser.add_argument('-f', '--fights', nargs='+', help='The IDs of the fights to analyze.', type=int, default=[])
+    encounter_group = analyze_parser.add_mutually_exclusive_group()
+    encounter_group.add_argument('-e', '--encounter', help='The ID of the encounter to analyze. Mutually exclusive with --name', type=int)
+    encounter_group.add_argument('-n', '--name', help='The name of the encounter to analyze. Mutually exclusive with --encounter')
 
     sub_parsers.add_parser(name='token', help='Get an access token for the Warcraft Logs API.')
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,0 +1,55 @@
+class ENCOUNTER:
+    ULDUAR_IDS = {
+        'Flame Leviathan': 744,
+        'Ignis the Furnace Master': 745,
+        'Razorscale': 746,
+        'XT-002 Deconstructor': 747,
+        'The Assembly of Iron': 748,
+        'Kologarn': 749,
+        'Auriaya': 750,
+        'Hodir': 751,
+        'Thorim': 752,
+        'Freya': 753,
+        'Mimiron': 754,
+        'General Vezax': 755,
+        'Yogg-Saron': 756,
+        'Algalon the Observer': 757,
+    }
+
+    TOGC_IDS = {
+        'The Northrend Beasts': 629,
+        'Lord Jaraxxus': 633,
+        'Faction Champions': 637,
+        "Twin Val'kyr": 641,
+        "Anub'arak": 645,
+    }
+
+    ICC_IDS = {
+        'Lord Marrowgar': 845,
+        'Lady Deathwhisper': 846,
+        'Icecrown Gunship Battle': 847,
+        'Deathbringer Saurfang': 848,
+        'Festergut': 849,
+        'Rotface': 850,
+        'Professor Putricide': 851,
+        'Blood Council': 852,
+        "Blood-Queen Lana'thel": 853,
+        'Valithria Dreamwalker': 854,
+        'Sindragosa': 855,
+        'The Lich King': 856,
+    }
+
+    IDS = {**ULDUAR_IDS, **TOGC_IDS, **ICC_IDS}
+    NAMES = {id: name for name, id in IDS.items()}
+
+    @staticmethod
+    def get_id(name: str) -> int:
+        if name not in ENCOUNTER.IDS:
+            raise ValueError(f"Unknown encounter name: {name}")
+        return ENCOUNTER.IDS[name]
+
+    @staticmethod
+    def get_name(id: int) -> str:
+        if id not in ENCOUNTER.NAMES:
+            raise ValueError(f"Unknown encounter ID: {id}")
+        return ENCOUNTER.NAMES[id]

--- a/src/models.py
+++ b/src/models.py
@@ -2,17 +2,29 @@ import argparse
 from dataclasses import dataclass
 from typing import List, Optional
 
+from src.constants import ENCOUNTER
+
 
 @dataclass
 class ReportRequest:
     code: str
-    encounter: Optional[str]
+    name: Optional[str]
+    encounter: Optional[int]
     fights: List[str]
 
     def __init__(self, args: argparse.Namespace):
         self.code = args.report
-        self.encounter = args.encounter
         self.fights = args.fights
+
+        if args.name is not None:
+            self.name = args.name
+            self.encounter = ENCOUNTER.get_id(args.name)
+        elif args.encounter is not None:
+            self.encounter = args.encounter
+            self.name = ENCOUNTER.get_name(args.encounter)
+        else:
+            self.name = None
+            self.encounter = None
 
 
 @dataclass


### PR DESCRIPTION
Closes #1 by adding the Ulduar, ToGC and ICC encounter IDs, and their corresponding names, as constants. It's up to the user whether they want to pass an ID `--encounter` or a name `--name` (mutually exclusive) to the tool.