### PR TITLE
Refactor and extend argument parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,26 +61,37 @@ To analyze a report, run the following command using the report ID from the URL 
 python main.py analyze <report ID>
 ```
 
-To restrict the analysis to a specific boss and/or fights, use the optional `--encounter` and `--fights` flags:
+To restrict the analysis to a specific boss and/or fights, use the optional `--name` (alternatively, `--encounter`) and `--fights` flags:
 
 ```bash
-python main.py analyze <report ID> --encounter <encounter ID> --fights <fight IDs>
+python main.py analyze <report ID> --name <encounter name> --fights <fight IDs>
 ```
 
 #### Example
 
-The ID of Lady Deathwhisper is 846.
+Here are some examples of the output of the `analyze` command:
 
 ```bash
-$ python main.py analyze TJwWr16NBgZdtyRY --encounter 846
+$ python main.py analyze TJwWr16NBgZdtyRY --name "Lady Deathwhisper"
 
 Retrieving report TJwWr16NBgZdtyRY from Warcraft Logs...
 Retrieved report TJwWr16NBgZdtyRY!
 
-Report consists of 5 fights, with the avg. ilvl ranging between 254.32 and 254.40:
+Report consists of 5 fights:
 - Wiped on Lady Deathwhisper (Heroic) at 77.59%
 - Wiped on Lady Deathwhisper (Heroic) at 67.06%
 - Wiped on Lady Deathwhisper (Heroic) at 40.07%
 - Wiped on Lady Deathwhisper (Heroic) at 99.98%
 - Killed Lady Deathwhisper (Normal)
+```
+
+```bash
+$ python main.py analyze TJwWr16NBgZdtyRY --encounter 848 --type wipes
+
+Retrieving report TJwWr16NBgZdtyRY from Warcraft Logs...
+Retrieved report TJwWr16NBgZdtyRY!
+
+Report consists of 2 fights:
+- Wiped on Deathbringer Saurfang (Heroic) at 55.28%
+- Wiped on Deathbringer Saurfang (Heroic) at 30.16%
 ```

--- a/main.py
+++ b/main.py
@@ -1,27 +1,9 @@
-import argparse
-
-from src import report, utils
+from src import arg_parser, report, utils
 from src.models import ReportRequest
 
 
-def parse_args() -> argparse.Namespace:
-    arg_parser = argparse.ArgumentParser(description='Analyze classic Warcraft Logs reports.')
-    sub_parsers = arg_parser.add_subparsers(dest='command', required=True)
-
-    analyze_parser = sub_parsers.add_parser(name='analyze', help='Analyze a Warcraft Logs report.')
-    analyze_parser.add_argument('report', help='The code of the report to analyze.')
-    analyze_parser.add_argument('-f', '--fights', nargs='+', help='The IDs of the fights to analyze.', type=int, default=[])
-    encounter_group = analyze_parser.add_mutually_exclusive_group()
-    encounter_group.add_argument('-e', '--encounter', help='The ID of the encounter to analyze. Mutually exclusive with --name', type=int)
-    encounter_group.add_argument('-n', '--name', help='The name of the encounter to analyze. Mutually exclusive with --encounter')
-
-    sub_parsers.add_parser(name='token', help='Get an access token for the Warcraft Logs API.')
-
-    return arg_parser.parse_args()
-
-
 def main():
-    args = parse_args()
+    args = arg_parser.parse_args()
 
     if args.command == 'analyze':
         report.analyze(ReportRequest(args))

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ def main():
     if args.command == 'analyze':
         report.analyze(ReportRequest(args))
     elif args.command == 'token':
-        print(utils.get_access_token())
+        print(utils.get_access_token(args.client_id, args.client_secret))
     else:
         raise ValueError(f'Unknown command: {args.command}')
 

--- a/src/arg_parser.py
+++ b/src/arg_parser.py
@@ -16,7 +16,7 @@ def _add_analyze_sub_parser(sub_parsers):
     analyze_parser.add_argument('report', help='The code of the report to analyze.')
     analyze_parser.add_argument('-f', '--fights', nargs='+', type=int, default=[],
                                 help='The IDs of the fights to analyze.')
-    analyze_parser.add_argument('-t', '--type', choices=['Wipes', 'Kills'], default='Encounters',
+    analyze_parser.add_argument('-t', '--type', choices=['wipes', 'kills'], default='encounters',
                                 help='The type of fights to analyze. Includes both kills and wipes by default.')
 
     encounter_group = analyze_parser.add_mutually_exclusive_group()

--- a/src/arg_parser.py
+++ b/src/arg_parser.py
@@ -5,16 +5,24 @@ def parse_args() -> argparse.Namespace:
     arg_parser = argparse.ArgumentParser(description='Analyze classic Warcraft Logs reports.')
     sub_parsers = arg_parser.add_subparsers(dest='command', required=True)
 
+    _add_analyze_sub_parser(sub_parsers)
+    _add_token_sub_parser(sub_parsers)
+
+    return arg_parser.parse_args()
+
+
+def _add_analyze_sub_parser(sub_parsers):
     analyze_parser = sub_parsers.add_parser(name='analyze', help='Analyze a Warcraft Logs report.')
     analyze_parser.add_argument('report', help='The code of the report to analyze.')
     analyze_parser.add_argument('-f', '--fights', nargs='+', type=int, default=[],
                                 help='The IDs of the fights to analyze.')
+
     encounter_group = analyze_parser.add_mutually_exclusive_group()
     encounter_group.add_argument('-e', '--encounter', type=int,
                                  help='The ID of the encounter to analyze. Mutually exclusive with --name')
     encounter_group.add_argument('-n', '--name',
                                  help='The name of the encounter to analyze. Mutually exclusive with --encounter')
 
-    sub_parsers.add_parser(name='token', help='Get an access token for the Warcraft Logs API.')
 
-    return arg_parser.parse_args()
+def _add_token_sub_parser(sub_parsers):
+    sub_parsers.add_parser(name='token', help='Get an access token for the Warcraft Logs API.')

--- a/src/arg_parser.py
+++ b/src/arg_parser.py
@@ -1,0 +1,20 @@
+import argparse
+
+
+def parse_args() -> argparse.Namespace:
+    arg_parser = argparse.ArgumentParser(description='Analyze classic Warcraft Logs reports.')
+    sub_parsers = arg_parser.add_subparsers(dest='command', required=True)
+
+    analyze_parser = sub_parsers.add_parser(name='analyze', help='Analyze a Warcraft Logs report.')
+    analyze_parser.add_argument('report', help='The code of the report to analyze.')
+    analyze_parser.add_argument('-f', '--fights', nargs='+', type=int, default=[],
+                                help='The IDs of the fights to analyze.')
+    encounter_group = analyze_parser.add_mutually_exclusive_group()
+    encounter_group.add_argument('-e', '--encounter', type=int,
+                                 help='The ID of the encounter to analyze. Mutually exclusive with --name')
+    encounter_group.add_argument('-n', '--name',
+                                 help='The name of the encounter to analyze. Mutually exclusive with --encounter')
+
+    sub_parsers.add_parser(name='token', help='Get an access token for the Warcraft Logs API.')
+
+    return arg_parser.parse_args()

--- a/src/arg_parser.py
+++ b/src/arg_parser.py
@@ -16,6 +16,8 @@ def _add_analyze_sub_parser(sub_parsers):
     analyze_parser.add_argument('report', help='The code of the report to analyze.')
     analyze_parser.add_argument('-f', '--fights', nargs='+', type=int, default=[],
                                 help='The IDs of the fights to analyze.')
+    analyze_parser.add_argument('-t', '--type', choices=['Wipes', 'Kills'], default='Encounters',
+                                help='The type of fights to analyze. Includes both kills and wipes by default.')
 
     encounter_group = analyze_parser.add_mutually_exclusive_group()
     encounter_group.add_argument('-e', '--encounter', type=int,

--- a/src/arg_parser.py
+++ b/src/arg_parser.py
@@ -25,4 +25,6 @@ def _add_analyze_sub_parser(sub_parsers):
 
 
 def _add_token_sub_parser(sub_parsers):
-    sub_parsers.add_parser(name='token', help='Get an access token for the Warcraft Logs API.')
+    token_parser = sub_parsers.add_parser(name='token', help='Get an access token for the Warcraft Logs API.')
+    token_parser.add_argument('--client_id', help='The client ID for the Warcraft Logs API.')
+    token_parser.add_argument('--client_secret', help='The client secret for the Warcraft Logs API.')

--- a/src/graphql.py
+++ b/src/graphql.py
@@ -32,10 +32,10 @@ def query_graphql(query: str, variables: dict) -> dict:
 
 def get_report(request: ReportRequest) -> Report:
     query = """
-        query ($code: String!, $encounterID: Int, $fightIDs: [Int]) {
+        query ($code: String!, $encounterID: Int, $fightIDs: [Int], $killType: KillType) {
             reportData {
                 report(code: $code) {
-                    fights(encounterID: $encounterID, fightIDs: $fightIDs) {
+                    fights(encounterID: $encounterID, fightIDs: $fightIDs, killType: $killType) {
                         encounterID
                         name
                         kill
@@ -50,7 +50,8 @@ def get_report(request: ReportRequest) -> Report:
     variables = {
         'code': request.code,
         'encounterID': request.encounter,
-        'fightIDs': request.fights
+        'fightIDs': request.fights,
+        'killType': request.type
     }
 
     data = query_graphql(query, variables)
@@ -63,6 +64,6 @@ def get_report(request: ReportRequest) -> Report:
         difficulty=json_fight['difficulty'],
         boss_percentage=json_fight['bossPercentage'],
         average_item_level=json_fight['averageItemLevel']
-    ) for json_fight in json_fights if json_fight['encounterID'] != 0]
+    ) for json_fight in json_fights]
 
     return Report(fights)

--- a/src/models.py
+++ b/src/models.py
@@ -16,7 +16,7 @@ class ReportRequest:
     def __init__(self, args: argparse.Namespace):
         self.code = args.report
         self.fights = args.fights
-        self.type = args.type
+        self.type = args.type.capitalize()
 
         if args.name is not None:
             self.name = args.name

--- a/src/models.py
+++ b/src/models.py
@@ -11,10 +11,12 @@ class ReportRequest:
     name: Optional[str]
     encounter: Optional[int]
     fights: List[str]
+    type: str
 
     def __init__(self, args: argparse.Namespace):
         self.code = args.report
         self.fights = args.fights
+        self.type = args.type
 
         if args.name is not None:
             self.name = args.name

--- a/src/report.py
+++ b/src/report.py
@@ -10,14 +10,10 @@ def analyze(request: ReportRequest):
 
     fights = report.fights
     if len(fights) == 0:
-        print("No fights found!")
+        print("No fights found matching the given criteria.")
         return
 
-    average_item_levels = [fight.average_item_level for fight in fights]
-    min_avg_ilvl, max_avg_ilvl = min(average_item_levels), max(average_item_levels)
-
-    print(f"Report consists of {len(fights)} fights, with the avg. ilvl "
-          f"ranging between {min_avg_ilvl:.2f} and {max_avg_ilvl:.2f}:")
+    print(f"Report consists of {len(fights)} fights:")
     for fight in fights:
         mode = "Heroic" if fight.difficulty == 4 else "Normal"
         if fight.kill:

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 
 import dotenv
 from requests_oauthlib import OAuth2Session
@@ -13,15 +14,22 @@ def get_env_var(key: str) -> str:
     return value
 
 
-def get_access_token() -> str:
+def get_access_token(client_id: Optional[str] = None, client_secret: Optional[str] = None) -> str:
     """Creates an OAuth2 session and retrieves an access token for the Warcraft Logs API.
-
-    Requires the `WCL_CLIENT_ID` and `WCL_CLIENT_SECRET` environment variables to be set.
+    Will prompt the user to visit a URL and enter the callback URL.
     See https://classic.warcraftlogs.com/api/docs for more information.
+
+    :param client_id: The client ID for the Warcraft Logs API. If None,
+           the `WCL_CLIENT_ID` environment variable will be used instead.
+    :param client_secret: The client secret for the Warcraft Logs API. If None,
+           the `WCL_CLIENT_SECRET` environment variable will be used instead.
+    :return: The access token.
     """
 
-    client_id = get_env_var('WCL_CLIENT_ID')
-    client_secret = get_env_var('WCL_CLIENT_SECRET')
+    if client_id is None:
+        client_id = get_env_var('WCL_CLIENT_ID')
+    if client_secret is None:
+        client_secret = get_env_var('WCL_CLIENT_SECRET')
 
     oauth = OAuth2Session(client_id, redirect_uri='https://localhost:5000/callback')
     authorization_url, _ = oauth.authorization_url('https://www.warcraftlogs.com/oauth/authorize')


### PR DESCRIPTION
- Refactored argument parser, moving it to a new file and splitting it into smaller helper functions.
- Added `--type` flag to the `analyze` command, letting users restrict the analysis to `wipes` or `kills`. Shows both by default.
- Added optional `--client_id` and `client_secret` flags to the `token` command. You can either pass them via the command, or by setting environment variables as defined earlier.